### PR TITLE
Make puppet-sssd work on Ubuntu

### DIFF
--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -169,6 +169,7 @@
 # @param ldap_tls_cert
 # @param ldap_tls_key
 # @param ldap_tls_cipher_suite
+# @param ldap_auth_disable_tls_never_use_in_production
 # @param ldap_id_use_start_tls
 # @param ldap_id_mapping
 # @param ldap_idmap_range_min
@@ -457,6 +458,7 @@ define sssd::domain (
   Optional[Stdlib::Absolutepath]                                                        $ldap_tls_cert                                 = undef,
   Optional[Stdlib::Absolutepath]                                                        $ldap_tls_key                                  = undef,
   Optional[String]                                                                      $ldap_tls_cipher_suite                         = undef,
+  Optional[Boolean]                                                                     $ldap_auth_disable_tls_never_use_in_production                         = undef,
   Optional[Boolean]                                                                     $ldap_id_use_start_tls                         = undef,
   Optional[Boolean]                                                                     $ldap_id_mapping                               = undef,
   Optional[Integer[0]]                                                                  $ldap_idmap_range_min                          = undef,
@@ -786,6 +788,7 @@ define sssd::domain (
     'ldap_tls_cert'                                 => $ldap_tls_cert,
     'ldap_tls_key'                                  => $ldap_tls_key,
     'ldap_tls_cipher_suite'                         => $ldap_tls_cipher_suite,
+    'ldap_auth_disable_tls_never_use_in_production' => $ldap_auth_disable_tls_never_use_in_production,
     'ldap_id_use_start_tls'                         => $ldap_id_use_start_tls,
     'ldap_id_mapping'                               => $ldap_id_mapping,
     'ldap_idmap_range_min'                          => $ldap_idmap_range_min,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,7 +45,7 @@ class sssd (
   Stdlib::Absolutepath                                                  $conf_dir                 = $::sssd::params::conf_dir,
   Stdlib::Absolutepath                                                  $conf_file                = $::sssd::params::conf_file,
   Hash[String, Hash[String, Any]]                                       $domains                  = {},
-  String                                                                $package_name             = $::sssd::params::package_name,
+  Array[String, 1]                                                      $package_name             = $::sssd::params::package_name,
   String                                                                $service_name             = $::sssd::params::service_name,
   Hash[String, Hash[String, Any]]                                       $services                 = {},
   Boolean                                                               $service_enable           = true,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,6 +24,28 @@ class sssd::params {
         default   => false,
       }
     }
+    'Debian': {
+      $conf_dir              = '/etc/sssd'
+      $conf_file             = "${conf_dir}/sssd.conf"
+      $dbus_package_name     = 'sssd-dbus'
+      $package_name          = 'sssd'
+      $service_name          = 'sssd'
+      $socket_services       = ['nss', 'pam', 'sudo', 'autofs', 'ssh', 'pac', 'secrets'].reduce({}) |Hash $memo, SSSD::Type $service| {
+        $memo + {
+          $service => $service ? {
+            'pam'   => [
+              "sssd-${service}.socket",
+              "sssd-${service}-priv.socket",
+            ],
+            default => "sssd-${service}.socket",
+          }
+        }
+      }
+      $use_socket_activation = $::service_provider ? {
+        'systemd' => true,
+        default   => false,
+      }
+    }
     default: {
       fail("The ${module_name} module is not supported on an ${::osfamily} based system.")
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,7 +6,7 @@ class sssd::params {
       $conf_dir              = '/etc/sssd'
       $conf_file             = "${conf_dir}/sssd.conf"
       $dbus_package_name     = 'sssd-dbus'
-      $package_name          = 'sssd'
+      $package_name          = ['sssd']
       $service_name          = 'sssd'
       $socket_services       = ['nss', 'pam', 'sudo', 'autofs', 'ssh', 'pac', 'secrets'].reduce({}) |Hash $memo, SSSD::Type $service| {
         $memo + {
@@ -28,7 +28,7 @@ class sssd::params {
       $conf_dir              = '/etc/sssd'
       $conf_file             = "${conf_dir}/sssd.conf"
       $dbus_package_name     = 'sssd-dbus'
-      $package_name          = 'sssd'
+      $package_name          = ['sssd', 'libpam-sss', 'libnss-sss']
       $service_name          = 'sssd'
       $socket_services       = ['nss', 'pam', 'sudo', 'autofs', 'ssh', 'pac', 'secrets'].reduce({}) |Hash $memo, SSSD::Type $service| {
         $memo + {


### PR DESCRIPTION
This PR intends to:

1. Add an option named `dap_auth_disable_tls_never_use_in_production` which is required when testing LDAP without TLS. See http://www.openkb.info/2017/11/how-to-configure-ldap-client-by-using.html .
2. Add support for Ubuntu OS which has been tested on Ubuntu 18. 