### PR TITLE
Bump dbus dependency

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -13,7 +13,7 @@ fixtures:
       ref: "0.6.2"
     dbus:
       repo: "bodgit/dbus"
-      ref: "2.0.1"
+      ref: "3.0.0"
     stdlib:
       repo: "puppetlabs/stdlib"
       ref: "7.1.0"

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "bodgit/dbus",
-      "version_requirement": ">=1.1.2 <3.0.0"
+      "version_requirement": ">=1.1.2 <4.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/default_module_facts.yml
+++ b/spec/default_module_facts.yml
@@ -1,2 +1,0 @@
----
-dbus_startup_provider: init


### PR DESCRIPTION
No longer need to maintain the dbus facts.

Fixes #25