### PR TITLE
feat: add session_provider arg to sssd::domain

### DIFF
--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -48,6 +48,7 @@
 # @param subdomains_provider
 # @param autofs_provider
 # @param hostid_provider
+# @param session_provider
 # @param re_expression
 # @param full_name_format
 # @param lookup_family_order
@@ -334,6 +335,7 @@ define sssd::domain (
   Optional[SSSD::Provider::Subdomains]                                                  $subdomains_provider                           = undef,
   Optional[SSSD::Provider::AutoFS]                                                      $autofs_provider                               = undef,
   Optional[SSSD::Provider::HostID]                                                      $hostid_provider                               = undef,
+  Optional[SSSD::Provider::Session]                                                     $session_provider                              = undef,
   Optional[String]                                                                      $re_expression                                 = undef,
   Optional[String]                                                                      $full_name_format                              = undef,
   Optional[Enum['ipv4_first', 'ipv4_only', 'ipv6_first', 'ipv6_only']]                  $lookup_family_order                           = undef,
@@ -632,6 +634,7 @@ define sssd::domain (
     'subdomains_provider'                           => $subdomains_provider,
     'autofs_provider'                               => $autofs_provider,
     'hostid_provider'                               => $hostid_provider,
+    'session_provider'                              => $session_provider,
     're_expression'                                 => $re_expression,
     'full_name_format'                              => $full_name_format,
     'lookup_family_order'                           => $lookup_family_order,

--- a/types/provider/session.pp
+++ b/types/provider/session.pp
@@ -1,0 +1,2 @@
+# @since 2.0.0
+type SSSD::Provider::Session = Enum['ipa', 'none']


### PR DESCRIPTION
Error with freeipa: https://github.com/SSSD/sssd/issues/5846
The fix is to define `session_provider = none`

excerpt of `man sssd.conf` :
```
       session_provider (string)
           The provider which configures and manages user session related tasks. The only user session
           task currently provided is the integration with Fleet Commander, which works only with IPA.
           Supported session providers are:

           “ipa” to allow performing user session related tasks.

           “none” does not perform any kind of user session related tasks.

           Default: “id_provider” is used if it is set and can perform session related tasks.

           NOTE: In order to have this feature working as expected SSSD must be running as "root" and
           not as the unprivileged user.
```