### PR TITLE
Replace deprecated has_key function

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -340,7 +340,7 @@ define sssd::service (
 
   if $use_socket_activation {
 
-    if has_key($sssd::socket_services, $service) {
+    if $service in $sssd::socket_services {
       Array($sssd::socket_services[$service], true).each |String $x| {
         service { $x:
           enable  => $sssd::service_enable,
@@ -352,7 +352,7 @@ define sssd::service (
 
     if $facts['service_provider'] == 'systemd' {
 
-      if has_key($sssd::socket_services, $service) {
+      if $service in $sssd::socket_services {
         Array($sssd::socket_services[$service], true).each |String $x| {
           service { $x:
             ensure  => stopped,


### PR DESCRIPTION
Function was removed from stdlib in v9.0.0:
https://github.com/puppetlabs/puppetlabs-stdlib/pull/1319