### PR TITLE
os: add openeuler support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,6 +31,13 @@ class sssd::params {
         default   => false,
       }
     }
+    'Openeuler': {
+      $package_name          = 'sssd'
+      $use_socket_activation = $facts['service_provider'] ? {
+        'systemd' => true,
+        default   => false,
+      }
+    }
     default: {
       fail("The ${module_name} module is not supported on an ${facts['os']['family']} based system.")
     }


### PR DESCRIPTION
**Pull Request (PR) description**
Add OS support openEuler for puppet-sssd

**This Pull Request (PR) fixes the following issues**
This PR add [openEuler](https://www.openeuler.org/) as a supporting OS. openEuler is a community-driven Linux distro.
We've tested it in our openEuler cluster. We appreciate it if this patch can be back ported to puppet-sssd repository.

Thank you!